### PR TITLE
Fix trailing semicolon in macro warning when building project

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ macro_rules! ensure_env {
                 eprintln!("{} must be set", $var);
                 process::exit(1);
             }
-        };
+        }
     };
 }
 


### PR DESCRIPTION
See: https://github.com/willdurand/dynhost/pull/15